### PR TITLE
Fix misuse of matchPath in sever file

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -19,7 +19,7 @@ server
     // First we iterate through our top level routes
     // looking for matches against the current url.
     const matches = routes.map((route, index) => {
-      const match = matchPath(req.url, route.path, route);
+      const match = matchPath(req.path, route);
       // We then look for static getInitialData function on each top level component
       if (match) {
         const obj = {


### PR DESCRIPTION
Hi,
I realized that there is a problem when we open `About` & it gets rendered by our server.
it seems that `getInitialData` method of the `Home` page is also called during the SSR.
when I looked for where the problem is coming from, I saw that the `matchPath` function is used incorrectly according to the documentation:
https://github.com/ReactTraining/react-router/blob/620ff29f65deef6aa6a65e65f46af16c914d735c/packages/react-router/docs/api/matchPath.md